### PR TITLE
Single test run for Github Actions

### DIFF
--- a/.github/workflows/django_stripe.yml
+++ b/.github/workflows/django_stripe.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/django_stripe.yml
+++ b/.github/workflows/django_stripe.yml
@@ -13,7 +13,7 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 3
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Github Actions doesn't allow sequential test runs. Tests are not setup to run in parallel due to Stripe API.